### PR TITLE
make post_install.sh idempotent

### DIFF
--- a/post_install.sh
+++ b/post_install.sh
@@ -4,4 +4,4 @@
 sysrc -f /etc/rc.conf plexmediaserver_enable="YES"
 
 # Start the service
-service plexmediaserver start 2>/dev/null
+service plexmediaserver restart 2>/dev/null


### PR DESCRIPTION
When plexmediaserver was previously installed and started this script exits with 1. A service restart does not fail even though the service was not started yet, so that the application is restarted after being updated.